### PR TITLE
[Shuttle #12] Fix ShuffleMaster constructor passes zkManager but is not used

### DIFF
--- a/src/main/java/com/oppo/shuttle/rss/server/master/ShuffleMaster.java
+++ b/src/main/java/com/oppo/shuttle/rss/server/master/ShuffleMaster.java
@@ -80,6 +80,7 @@ public class ShuffleMaster extends ShuffleServer {
     public ShuffleMaster(ShuffleServerConfig masterConfig, ZkShuffleServiceManager zkManager) {
         this.masterConfig = masterConfig;
         this.localIp = NetworkUtils.getLocalIp();
+        this.zkManager = zkManager;
         init();
     }
 


### PR DESCRIPTION
To close #12 